### PR TITLE
BMP Toggle workaround

### DIFF
--- a/app/views/bmps/index.html.erb
+++ b/app/views/bmps/index.html.erb
@@ -520,36 +520,32 @@
 	var validateBmpLl = new Validator("bmpsForm");
 	var validateBmpTs = new Validator("bmpsForm");
 	var validateBmpCc = new Validator("bmpsForm");
-    //show/hide bmps on click-'let' makes 'i' local to loop instead of global
-    for(let i = 1; i < 20; i++) {
-        //BMP toggle (show/hide)
-        $("#bmp"+i).click(function() {
-          if (msie > 0 || trident > 0 || edge > 0) { //If IE
-            //extracts id # from id of element clicked (e.g. bmp3 = 3)
-            var elementIDNum = (this.id).replace(/[^0-9]+/g, "");
-            var clicked = $("#"+elementIDNum);
-            $(".toggable").not(this).hide();
-            clicked.toggle();
-          } else {
-            //$("#"+i).toggle(); //all bmps can be toggled
-            var $this = $("#"+i);
-            $(".toggable").not($this).hide();
-            $this.toggle();
-          }
-        });
-        //checking box will show BMP, unchecking hides & clears BMP input
-        $('#select_'+i).change(function () {
-          //extracts id # from id of element clicked (e.g. checkbox_3 = 3)
-          var elementIDNum = (this.id).replace(/[^0-9]+/g, "");
-          var check = $("#"+elementIDNum);
-          if (!this.checked) { //unchecked
+    //BMP Toggle (show/hide)
+    $('[id^=bmp]').click(function() {
+    	//extracts id # from id of element clicked (e.g. bmp3 = 3)
+		var elementIDNum = (this.id).replace(/[^0-9]+/g, "");
+		var concat = "#" + elementIDNum;
+		var clicked = $("#"+elementIDNum);
+		clicked.each(function(i, elem) {
+			$(".toggable").not(this).hide(); //shows one BMP at a time
+			//toggle functionality workaround compatible with IE
+			$(elem).toggle($(elem).css('display') == 'none');
+     	});
+   	});
+   	//Checking box will show BMP, unchecking hides & clears BMP input
+   	$('[id^=select').change(function() {
+   		//extracts id # from id of element clicked (e.g. checkbox_3 = 3)
+   		var elementIDNum = (this.id).replace(/[^0-9]+/g, "");
+        var check = $("#"+elementIDNum);
+        if (!this.checked) { //unchecked
           	check.hide();
           	$("tbody#" + elementIDNum + " input").each(function() {
                 this.value="";
                 $("tbody#" + elementIDNum + " input").not(this).attr('checked', false);
                 $("tbody#" + elementIDNum + " select").val([]);
               });
-            //removes validations when checkbox unchecked
+            //unchecked - remove validations & hide inputs
+            //minor bug if user unchecks while other BMPs are checked (clears ALL validations)
             if (elementIDNum == 1) {
               validateBmpAi.clearAllValidations();
             } else if (elementIDNum == 3) {
@@ -573,7 +569,7 @@
             } else if (elementIDNum == 19) {
                 validateBmpCc.clearAllValidations();
             }
-          } else { //add validations for inputs when checkbox checked
+          } else { //checked - add validations & reveal inputs
             check.show();
             if (elementIDNum == 1) {
               validationsBmpAi();
@@ -613,8 +609,7 @@
                 } else { confirm_check(elementIDNum); }
               }
           }
-        });
-    }
+   	});
   function prompt_user() {
     var r = confirm("It appears you have a similar BMP already checked. Continuing will clear any input you may have had for the other BMP.");
     if (r == true) {


### PR DESCRIPTION
This workaround resolves a possible [known bug](https://bugs.jquery.com/ticket/4661) jQuery .toggle function has with Internet Explorer. Toggle on IE is now 100% functioning, previously only having the display property working from the display/hide functionality.